### PR TITLE
SlowMovie Help Testing Displays

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -14,9 +14,7 @@ import os, time, sys, random
 from PIL import Image
 import ffmpeg
 import argparse
-
-# Ensure this is the correct import for your particular screen
-from inky.inky_uc8159 import Inky, CLEAN
+from omni_epd import displayfactory
 
 
 def generate_frame(in_filename, out_filename, time, width, height):
@@ -34,16 +32,6 @@ def check_mp4(value):
     if not value.endswith(".mp4"):
         raise argparse.ArgumentTypeError("%s should be an .mp4 file" % value)
     return value
-
-
-def inky_clear(inky):
-    for _ in range(2):
-        for y in range(inky.height - 1):
-            for x in range(inky.width - 1):
-                inky.set_pixel(x, y, CLEAN)
-
-        inky.show()
-        time.sleep(1.0)
 
 
 # Ensure this is the correct path to your video folder
@@ -152,11 +140,12 @@ if args.file:
 print("The current video is %s" % currentVideo)
 
 # Ensure this is the correct driver for your particular screen
-inky = Inky()
+epd = displayfactory.load_display_driver('inky.impression')
 
 # Initialise and clear the screen
 print("Clearing the screen")
-inky_clear(inky)
+epd.prepare()
+epd.clear()
 
 currentPosition = 0
 
@@ -171,8 +160,8 @@ if args.start:
     currentPosition = float(args.start)
 
 # Set the width and height of the screen from the Inky library
-width = inky.width
-height = inky.height
+width = epd.width
+height = epd.height
 
 inputVid = viddir + currentVideo
 
@@ -196,8 +185,9 @@ while 1:
     pil_im = Image.open("grab.jpg")
 
     # display the image
-    inky.set_image(pil_im, saturation=float(args.saturation))
-    inky.show()
+    epd.prepare()  # not strictly needed for inky but other displays might implement this
+    epd.display(pil_im)
+
     print("Diplaying frame %d of %s" % (frame, currentVideo))
 
     currentPosition = currentPosition + increment


### PR DESCRIPTION
This isn't strictly a PR but the best way I could find to contact you. I'm one of the maintainers on the original [SlowMovie repo](https://github.com/TomWhitwell/SlowMovie). We've been trying to enhance that project by providing support for [multiple EPD display](https://github.com/TomWhitwell/SlowMovie/pull/64) types by using [a library](https://github.com/robweber/omni-epd) instead of people having to modify the source for each type of display. I'm reaching out since I noticed you modified the original to work with a different display type than the default Waveshare 7.5in one Tom had in his original instructions. 

Would you be interested in helping to test the multiple EPD feature we're trying to implement? We'd like to get a few actual hardware displays tested before merging it all in. In this PR I've modified your code to use the `omni-epd` library by replacing the required method calls and adding the right Python import. To test all you'll need to do is install the library using: `sudo pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd` and run `slowmovie.py` as normal. 

Thanks in advance for any help. 